### PR TITLE
Add support for ingredient conversions.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -326,6 +326,59 @@
     }
   },
   {
+    "name": "ingredientConversion",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "ingredientConversion"
+          }
+        },
+        "to": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "object",
+            "attributes": {
+              "_ref": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "reference"
+                }
+              },
+              "_weak": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "boolean"
+                },
+                "optional": true
+              }
+            },
+            "dereferencesTo": "ingredient"
+          },
+          "optional": true
+        },
+        "rate": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "imageGallery",
     "type": "type",
     "value": {
@@ -1440,6 +1493,28 @@
         "value": {
           "type": "inline",
           "name": "ingredientWeights"
+        },
+        "optional": true
+      },
+      "conversions": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_key": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "rest": {
+              "type": "inline",
+              "name": "ingredientConversion"
+            }
+          }
         },
         "optional": true
       }

--- a/src/components/Recipe/RecipeIngredientReference.tsx
+++ b/src/components/Recipe/RecipeIngredientReference.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { RecipeIngredientReference } from "./types";
-import { useRecipeContext } from "./recipeContext";
-import { formatAmount } from "@/utils/recipeUtils";
 import { HighlightWithCheckbox } from "@/components/PortableText/HighlightWithCheckbox";
+import { formatAmount } from "@/utils/recipeUtils";
 import { isDefined, unCapitalize } from "@/utils/tsUtils";
-import { Highlight } from "../PortableText/Highlight";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/react/shallow";
+import { Highlight } from "../PortableText/Highlight";
+import { useRecipeContext } from "./recipeContext";
+import { RecipeIngredientReference } from "./types";
 
 interface RecipeIngredientReferenceResultProps {
   value: NonNullable<RecipeIngredientReference>;
@@ -37,7 +37,7 @@ export const RecipeIngredientReferenceResult = ({
 
   const { percentage: referencePercentage, hideCheckbox } = value;
 
-  const { _id, name } = value.ingredient;
+  const { _id } = value.ingredient;
 
   const ingredientState = ingredients.find((i) => i.id === _id);
 
@@ -50,7 +50,7 @@ export const RecipeIngredientReferenceResult = ({
     ? `${formatAmount(mappedAmount, ingredientState?.unit)} `
     : "";
 
-  const labelText = `${amountLabel}${unCapitalize(name)}${ingredientState?.comment ? ` (${ingredientState.comment})` : ""}`;
+  const labelText = `${amountLabel}${unCapitalize(ingredientState?.name)}${ingredientState?.comment ? ` (${ingredientState.comment})` : ""}`;
 
   return hideCheckbox ? (
     <Highlight>{labelText}</Highlight>

--- a/src/components/Recipe/store/initialState.ts
+++ b/src/components/Recipe/store/initialState.ts
@@ -1,17 +1,17 @@
 import { OmitStrict } from "@/utils/types";
 import { RecipeQueryResult } from "../../../../sanity.types";
 import {
+  RecipeIngredient,
+  RecipeIngredients,
+  RecipeInstructions,
+} from "../types";
+import {
   IngredientsCompletionState,
   IngredientsGroupOrder,
   RecipeIngredientsState,
   RecipeIngredientState,
   RecipeState,
 } from "./types";
-import {
-  RecipeIngredient,
-  RecipeIngredients,
-  RecipeInstructions,
-} from "../types";
 import { calcIngredientAmount, calculateTotalYield } from "./utils";
 
 const calcInitialIngredientsCompletionState = (
@@ -71,6 +71,16 @@ const mapIngredientReferenceToIngredient = (
       ss: ingredient.weights?.tablespoon ?? null,
       ts: ingredient.weights?.teaspoon ?? null,
     },
+    conversions:
+      ingredient.conversions?.map((c) => ({
+        to: c.to?.name ?? "Unknown",
+        rate: c.rate ?? 1,
+        weights: {
+          l: c.to?.weights?.liter ?? null,
+          ss: c.to?.weights?.tablespoon ?? null,
+          ts: c.to?.weights?.teaspoon ?? null,
+        },
+      })) ?? [],
     comment: comment,
   };
 };

--- a/src/components/Recipe/store/types.ts
+++ b/src/components/Recipe/store/types.ts
@@ -32,6 +32,21 @@ export const ingredientUnit = v.union([
   v.literal("l"),
 ]);
 
+const weights = v.object({
+  l: v.nullable(v.number()),
+  ss: v.nullable(v.number()),
+  ts: v.nullable(v.number()),
+});
+
+const conversions = v.array(
+  v.object({
+    to: v.string(),
+    rate: v.number(),
+    weights: weights,
+  }),
+);
+export type Conversions = v.InferInput<typeof conversions>;
+
 const recipeIngredientStateSchema = v.object({
   id: v.string(),
   name: v.string(),
@@ -39,13 +54,11 @@ const recipeIngredientStateSchema = v.object({
   percent: v.optional(v.number()),
   amount: v.optional(v.number()),
   unit: v.optional(v.union([ingredientUnit, v.undefined(), v.null()])),
-  weights: v.object({
-    l: v.nullable(v.number()),
-    ss: v.nullable(v.number()),
-    ts: v.nullable(v.number()),
-  }),
+  weights: weights,
   comment: v.optional(v.nullable(v.string())),
+  conversions,
 });
+
 export type RecipeIngredientState = v.InferInput<
   typeof recipeIngredientStateSchema
 >;

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -61,7 +61,14 @@ export const recipeIngredientReferenceFields = /* groq */ `
   _id,
   "ingredient": ingredient->{
     name,
-    weights
+    weights,
+    conversions[] {
+      to->{
+        name,
+        weights,
+      },
+      rate,
+    }
   },
   unit,
   percent,

--- a/src/sanity/schemaTypes/constants.ts
+++ b/src/sanity/schemaTypes/constants.ts
@@ -2,5 +2,6 @@ export const alertTypeName = "alert";
 export const imageGalleryTypeName = "imageGallery";
 export const ingredientTypeName = "ingredient";
 export const homeTypeName = "home";
+export const ingredientConversionTypeName = "ingredientConversion";
 
 export const blockContentTypeName = "blockContent";

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -17,6 +17,7 @@ import { alertType } from "./alertType";
 import { initialValueTemplates } from "./initialValueTemplates";
 import { imageGalleryType } from "./imageGallery";
 import { ingredientWeightsType } from "./ingredientWeightsType";
+import { ingredientConversionType } from "./ingredientConversionType";
 
 export const schema: SchemaPluginOptions = {
   types: [
@@ -36,6 +37,7 @@ export const schema: SchemaPluginOptions = {
     alertType,
     imageGalleryType,
     ingredientWeightsType,
+    ingredientConversionType,
   ],
   templates: initialValueTemplates,
 };

--- a/src/sanity/schemaTypes/ingredientConversionType.ts
+++ b/src/sanity/schemaTypes/ingredientConversionType.ts
@@ -1,0 +1,36 @@
+import { defineField, defineType } from "sanity";
+import { ingredientConversionTypeName, ingredientTypeName } from "./constants";
+
+const fields = [
+  defineField({
+    name: "to",
+    type: "reference",
+    to: [{ type: ingredientTypeName }],
+    validation: (rule) => rule.required(),
+  }),
+  defineField({
+    name: "rate",
+    type: "number",
+    title: "Rate",
+    description:
+      "The rate of conversion. What is 1g of this ingredient in the other ingredient?",
+    validation: (rule) => rule.required(),
+  }),
+];
+
+export const ingredientConversionType = defineType({
+  name: ingredientConversionTypeName,
+  type: "object",
+  fields,
+  preview: {
+    select: {
+      to: "to.name",
+      rate: "rate",
+    },
+    prepare({ to, rate }) {
+      return {
+        title: `1g to ${rate}g of ${to}`,
+      };
+    },
+  },
+});

--- a/src/sanity/schemaTypes/ingredientType.ts
+++ b/src/sanity/schemaTypes/ingredientType.ts
@@ -1,5 +1,5 @@
 import { defineField, defineType } from "sanity";
-import { ingredientTypeName } from "./constants";
+import { ingredientConversionTypeName, ingredientTypeName } from "./constants";
 import { MatpratNameInput } from "../components/MatpratNameInput";
 
 const fields = [
@@ -34,6 +34,11 @@ const fields = [
   defineField({
     name: "weights",
     type: "ingredientWeights",
+  }),
+  defineField({
+    name: "conversions",
+    type: "array",
+    of: [{ type: ingredientConversionTypeName }],
   }),
 ];
 


### PR DESCRIPTION
Add support for specifying ingredient conversions in Sanity. This allows
conversions between different ingredients, such as dry or fresh yeast.
Add support for this functionality in the IngredientEditor.